### PR TITLE
adding in missing splice rules to yaml entries

### DIFF
--- a/yaml_files/0aec60da55ff46d794897760879acd48.yml
+++ b/yaml_files/0aec60da55ff46d794897760879acd48.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/131bb6c7826b467d9f1ea6bd3fa74175.yml
+++ b/yaml_files/131bb6c7826b467d9f1ea6bd3fa74175.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/1ed5a6870903426abef500c6bc060a37.yml
+++ b/yaml_files/1ed5a6870903426abef500c6bc060a37.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/23ca9f2b5ed244ed931dd19566e04aac.yml
+++ b/yaml_files/23ca9f2b5ed244ed931dd19566e04aac.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/2413d567033a4915bf1457c7b362c79b.yml
+++ b/yaml_files/2413d567033a4915bf1457c7b362c79b.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/260df0db210143dcbecf3182e24817a3.yml
+++ b/yaml_files/260df0db210143dcbecf3182e24817a3.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/2b27641b9bfe4d5ba9f9e91e6f684616.yml
+++ b/yaml_files/2b27641b9bfe4d5ba9f9e91e6f684616.yml
@@ -1,3 +1,5 @@
-# one of: public|registered|restricted
+splice rules:
+  accessType: default
+  licenceUrl: default# one of: public|registered|restricted
 accessType: public
 licenceUrl: http://licences.ceda.ac.uk/image/data_access_condition/esacci_seaice_terms_and_conditions.pdf

--- a/yaml_files/2c0bb6679e4f4a0ba1bc254167b171d8.yml
+++ b/yaml_files/2c0bb6679e4f4a0ba1bc254167b171d8.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/3913c555e3054ffa99eb494a1c0bb39d.yml
+++ b/yaml_files/3913c555e3054ffa99eb494a1c0bb39d.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/3922e45b2d764ae196cb06a941e1beb7.yml
+++ b/yaml_files/3922e45b2d764ae196cb06a941e1beb7.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/4f1777eefb514ab9a9b293e4cc0dda0c.yml
+++ b/yaml_files/4f1777eefb514ab9a9b293e4cc0dda0c.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/4f314945d3944aeaa12f819fe801dea0.yml
+++ b/yaml_files/4f314945d3944aeaa12f819fe801dea0.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/5116f09e13c84454888fd0e2466352ec.yml
+++ b/yaml_files/5116f09e13c84454888fd0e2466352ec.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/54988e5b7aff4e929ac02e73f3c777ca.yml
+++ b/yaml_files/54988e5b7aff4e929ac02e73f3c777ca.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/590adf7dbf6c4525bbcbbb08623d1e05.yml
+++ b/yaml_files/590adf7dbf6c4525bbcbbb08623d1e05.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/5f8d2c32121a4885b20be2ae96aed72d.yml
+++ b/yaml_files/5f8d2c32121a4885b20be2ae96aed72d.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/66486d43646c4f9db8bbde0efe1694ab.yml
+++ b/yaml_files/66486d43646c4f9db8bbde0efe1694ab.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/676d7fef735b49d5926d3a38fc239d09.yml
+++ b/yaml_files/676d7fef735b49d5926d3a38fc239d09.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/6a7935465d374c7a9eac70c046f4cfcb.yml
+++ b/yaml_files/6a7935465d374c7a9eac70c046f4cfcb.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/6ca85a41897244d2bc952c869091187d.yml
+++ b/yaml_files/6ca85a41897244d2bc952c869091187d.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/6e3e699fa0d3479b96dd990c0ce417ba.yml
+++ b/yaml_files/6e3e699fa0d3479b96dd990c0ce417ba.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/6fcc9d2c792243c1bb99de9c3cfdef2f.yml
+++ b/yaml_files/6fcc9d2c792243c1bb99de9c3cfdef2f.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: https://github.com/IPCC-WG1/Chapter-7/blob/main/LICENSE

--- a/yaml_files/6fef2353826b47c3bebbc30fd036552c.yml
+++ b/yaml_files/6fef2353826b47c3bebbc30fd036552c.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/70c57074146147989150a1a37c338fcf.yml
+++ b/yaml_files/70c57074146147989150a1a37c338fcf.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/710ec325988347e5bff6499c04b4beb8.yml
+++ b/yaml_files/710ec325988347e5bff6499c04b4beb8.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/7464dd2803774dbbb21bd97fddccaa39.yml
+++ b/yaml_files/7464dd2803774dbbb21bd97fddccaa39.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/789ad030299342ea99534edfb62450d9.yml
+++ b/yaml_files/789ad030299342ea99534edfb62450d9.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/7c114fc6e2884c1f9ca107e7a502fdbf.yml
+++ b/yaml_files/7c114fc6e2884c1f9ca107e7a502fdbf.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://licences.ceda.ac.uk/image/data_access_condition/esacci_landcover_terms_and_conditions.pdf

--- a/yaml_files/81784e3642bd465aa69c7fd40ffe1b1b.yml
+++ b/yaml_files/81784e3642bd465aa69c7fd40ffe1b1b.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: https://www.ecad.eu/documents/ECAD_datapolicy.pdf

--- a/yaml_files/85168bf5e6ee4733b8f9d486890148f6.yml
+++ b/yaml_files/85168bf5e6ee4733b8f9d486890148f6.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/87e8b101187643d382dc2c01277bd193.yml
+++ b/yaml_files/87e8b101187643d382dc2c01277bd193.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/89e1b69ad74146cfa8b0a941108811c2.yml
+++ b/yaml_files/89e1b69ad74146cfa8b0a941108811c2.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/8bbde1a8a0ce4a86904a3d7b2b917955.yml
+++ b/yaml_files/8bbde1a8a0ce4a86904a3d7b2b917955.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://licences.ceda.ac.uk/image/data_access_condition/esacci_seaice_terms_and_conditions.pdf

--- a/yaml_files/8e0b3004ed5a4b45b7b0538347b5c85a.yml
+++ b/yaml_files/8e0b3004ed5a4b45b7b0538347b5c85a.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/980a7c11d834455eb75752fdf7830719.yml
+++ b/yaml_files/980a7c11d834455eb75752fdf7830719.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/ab9bf1524e134398b693f09b5199412b.yml
+++ b/yaml_files/ab9bf1524e134398b693f09b5199412b.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/afed8436512e4bc1b02320e18132815f.yml
+++ b/yaml_files/afed8436512e4bc1b02320e18132815f.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/b140e520e22e45daa8525d18c1c8cced.yml
+++ b/yaml_files/b140e520e22e45daa8525d18c1c8cced.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/b2670fb9d6e14733b303865c85c2065d.yml
+++ b/yaml_files/b2670fb9d6e14733b303865c85c2065d.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: https://www.ecad.eu/documents/ECAD_datapolicy.pdf

--- a/yaml_files/b57ed5886f0a4041b76f2281ba503bed.yml
+++ b/yaml_files/b57ed5886f0a4041b76f2281ba503bed.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/b9bae3ebc72643b0a91396064097bf74.yml
+++ b/yaml_files/b9bae3ebc72643b0a91396064097bf74.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/b9d3cd0654be4360b295e0e277897d4c.yml
+++ b/yaml_files/b9d3cd0654be4360b295e0e277897d4c.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/bb671075bd194b3bbaa496d90f5310e1.yml
+++ b/yaml_files/bb671075bd194b3bbaa496d90f5310e1.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/bd83322fc85e4a58a08ae19f298a0ac2.yml
+++ b/yaml_files/bd83322fc85e4a58a08ae19f298a0ac2.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: registered
 licenceUrl: http://www.ukssdc.ac.uk/cgi-bin/wdcc1/userreg.pl

--- a/yaml_files/c57d3e07c72249c38fe6b019924119d5.yml
+++ b/yaml_files/c57d3e07c72249c38fe6b019924119d5.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/c79b18c2fcdf41ada4b8e1562bea7411.yml
+++ b/yaml_files/c79b18c2fcdf41ada4b8e1562bea7411.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/cf7bbe0b427e497084a80dd313630c3f.yml
+++ b/yaml_files/cf7bbe0b427e497084a80dd313630c3f.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/da2cbd8729374098b2beae671bf6d072.yml
+++ b/yaml_files/da2cbd8729374098b2beae671bf6d072.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/db756b9651da4e11b9ca2a0c3cce64b1.yml
+++ b/yaml_files/db756b9651da4e11b9ca2a0c3cce64b1.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/dc8c9a1dfba24a0187e22740404385fd.yml
+++ b/yaml_files/dc8c9a1dfba24a0187e22740404385fd.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/e68742b4c4724559b704b29a15981c76.yml
+++ b/yaml_files/e68742b4c4724559b704b29a15981c76.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/e80f28ccb0504c32b403eee654a8a5b3.yml
+++ b/yaml_files/e80f28ccb0504c32b403eee654a8a5b3.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://licences.ceda.ac.uk/image/data_access_condition/esacci_landcover_terms_and_conditions.pdf

--- a/yaml_files/f2bd3cf541b24177bfc33dc0dc48695d.yml
+++ b/yaml_files/f2bd3cf541b24177bfc33dc0dc48695d.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: http://creativecommons.org/licenses/by/4.0/

--- a/yaml_files/fab3d1d8abce46f6a53270b0b48a9312.yml
+++ b/yaml_files/fab3d1d8abce46f6a53270b0b48a9312.yml
@@ -1,4 +1,6 @@
-
+splice rules:
+  accessType: default
+  licenceUrl: default
 # one of: public|registered|restricted
 accessType: public
 licenceUrl: https://www.eumetsat.int/data-policy/eumetsat-data-policy.pdf


### PR DESCRIPTION
This pull requests adds missing splice rules for yaml files created last year to prepare for the switch to MOLES pulling licence and access info from the access instructor. These YAML files were created to cover items not in the access instructor (e.g. off lline/external resources). 